### PR TITLE
Update the IP address used to be within VirtualBox's allowed ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You may wish to configure a hosts entry for easily accessing the VM, if so add
 the following line to `/etc/hosts` on the *host* machine:
 
 ```
-192.168.42.42  sr-vm sr-vm.local
+192.168.56.56  sr-vm sr-vm.local
 ```
 
 ## Deployment

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(2) do |config|
     v.cpus = 4
   end
 
-  config.vm.network "private_network", ip: "192.168.42.42"
+  config.vm.network "private_network", ip: "192.168.56.56"
   config.vm.hostname = "sr-vm.local"
 
   # Required so that apt cache is populated before ansible runs


### PR DESCRIPTION
Not sure when this changed (.42.42 has worked fine in the past), but ~Vagrant 2.2.19~ VirtualBox 6.1 now complains about this. It does mention that the ranges are customisable by editing `/etc/vbox/networks.conf`, but I don't think we want to force people to do that.