### PR TITLE
Prefer more modern redirects

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -59,7 +59,8 @@ http {
     listen [::]:443 default_server ssl http2 fastopen=256;
 
     location / {
-      return 302 https://{{ canonical_hostname }}$request_uri;
+      # Temporary redirect to avoid clobbering unknown domains.
+      return 307 https://{{ canonical_hostname }}$request_uri;
     }
   }
 


### PR DESCRIPTION
## Summary

307 (and 308) has better defined semantics than 302 (and 301) both in terms of method switching (the former disallow it) and in terms of whether the redirect is cached or not.

## Code review

### Testing

Manually checked that locally this produces the expected HTTP change.

Here's the relevant part of running with `--check -diff`:
``` diff
--- before: /etc/nginx/nginx.conf
+++ after: /home/peter/.ansible/tmp/ansible-local-147672ptulfurx/tmpt7ly6iz2/nginx.conf
@@ -50,7 +50,8 @@
     listen [::]:443 default_server ssl http2 fastopen=256;
 
     location / {
-      return 302 https://studentrobotics.org$request_uri;
+      # Temporary redirect to avoid clobbering unknown domains.
+      return 307 https://studentrobotics.org$request_uri;
     }
   }
 
```

### Links

Builds on #5 for development convenience.
