### PR TITLE
Remove mention of the beta domain

### DIFF
--- a/host_vars/monty.studentrobotics.org.yml
+++ b/host_vars/monty.studentrobotics.org.yml
@@ -1,6 +1,6 @@
 ---
 canonical_hostname: studentrobotics.org
-secondary_hostnames: beta.studentrobotics.org
+secondary_hostnames:
 
 add_hsts_header: true
 certbot_create_if_missing: true
@@ -10,5 +10,4 @@ certbot_certs:
       - www.studentrobotics.org
       - srobo.org
       - www.srobo.org
-      - beta.studentrobotics.org
       - monty.studentrobotics.org


### PR DESCRIPTION
## Summary

We're not in beta any more.

## Code review

### Testing

Ran manually with `--check --diff`, the result was as expected:
``` diff
--- before: /etc/nginx/nginx.conf
+++ after: /home/peter/.ansible/tmp/ansible-local-14855080je934e/tmp_3ir4wxt/nginx.conf
@@ -50,7 +50,8 @@
     listen [::]:443 default_server ssl http2 fastopen=256;
 
     location / {
-      return 302 https://studentrobotics.org$request_uri;
+      # Temporary redirect to avoid clobbering unknown domains.
+      return 307 https://studentrobotics.org$request_uri;
     }
   }
 
@@ -60,7 +61,7 @@
     # several server blocks can listen to the same port).
     listen         443 ssl;
     listen         [::]:443 ssl;
-    server_name    studentrobotics.org beta.studentrobotics.org;
+    server_name    studentrobotics.org ;
     root           /var/www;
 
     proxy_pass_request_headers on;

changed: [monty.studentrobotics.org]
```

Note that this includes changes from #6.

### Links

Fixes https://github.com/srobo/ansible/issues/3

Builds on #6 for development convenience.