### PR TITLE
Create a shortlink for access to livestream assets

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -208,6 +208,8 @@ http {
 
     # Volunteering Links
     rewrite ^/join                 https://docs.google.com/forms/d/e/1FAIpQLSdP55Lz_qNEx7t-hdQctt2VzXdYikOe9k2dKsDzEZZG7-nqTw/viewform redirect;
+    
+    rewrite ^/livestream-assets    https://drive.google.com/drive/folders/1pr1vKpnonxFoO8O5chsH5DF7Vsd0Tfih?usp=sharing redirect;
 
     # We have renamed the news section to blog
     rewrite ^/news/(.*) /blog/$1/ redirect;


### PR DESCRIPTION
## Summary

This makes them easy to access from devices which aren't authenticated with a Google account.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

### Links

https://drive.google.com/drive/folders/1pr1vKpnonxFoO8O5chsH5DF7Vsd0Tfih?usp=sharing
