### PR TITLE
Add short link to reference the livestream URL

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -210,7 +210,7 @@ http {
     rewrite ^/join                 https://docs.google.com/forms/d/e/1FAIpQLSdP55Lz_qNEx7t-hdQctt2VzXdYikOe9k2dKsDzEZZG7-nqTw/viewform redirect;
     
     # Short link for livestream embed, mostly for use in kiosk screens and other automation
-    rewrite ^/comp-livestream      https://www.youtube-nocookie.com/embed/7HNG2bqwXlo redirect;
+    rewrite ^/livestream      https://www.youtube-nocookie.com/embed/7HNG2bqwXlo redirect;
 
     # We have renamed the news section to blog
     rewrite ^/news/(.*) /blog/$1/ redirect;

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -208,6 +208,9 @@ http {
 
     # Volunteering Links
     rewrite ^/join                 https://docs.google.com/forms/d/e/1FAIpQLSdP55Lz_qNEx7t-hdQctt2VzXdYikOe9k2dKsDzEZZG7-nqTw/viewform redirect;
+    
+    # Short link for livestream embed, mostly for use in kiosk screens and other automation
+    rewrite ^/comp-livestream      https://www.youtube-nocookie.com/embed/7HNG2bqwXlo redirect;
 
     # We have renamed the news section to blog
     rewrite ^/news/(.*) /blog/$1/ redirect;


### PR DESCRIPTION
## Summary

This means we can just update this URL, rather than needing to update it in a bunch of different locations

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour
