### PR TITLE
Make the competition homepage mode configurable

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,6 +10,11 @@ certbot_create_standalone_stop_services:
  - nginx
 
 
+# Override serving of the root url to be the competition mode homepage instead
+# of the normal one.
+enable_competition_homepage: false
+
+
 firewall_allowed_tcp_ports:
  - "22"
  - "80"

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -119,18 +119,20 @@ http {
 
     # During the competition we un-comment this block to override the homepage
     # with the competition-specific one
-    # location = / {
-    #   proxy_pass       https://srobo.github.io/competition-website/comp/;
-    #   proxy_set_header Host srobo.github.io;
-    #
-    #   sub_filter "/competition-website/comp/" "/comp/";
-    #   sub_filter_once off;
-    #   sub_filter_last_modified on;
-    #   # Tell GitHub that we want these pages to be sent to us uncompressed
-    #   # otherwise the sub_filter above doesn't work. We'll compress it on the
-    #   # way out anyway, so clients don't lose anything by us doing this.
-    #   proxy_set_header Accept-Encoding "";
-    # }
+    {% if enable_competition_homepage %}
+      location = / {
+        proxy_pass       https://srobo.github.io/competition-website/comp/;
+        proxy_set_header Host srobo.github.io;
+
+        sub_filter "/competition-website/comp/" "/comp/";
+        sub_filter_once off;
+        sub_filter_last_modified on;
+        # Tell GitHub that we want these pages to be sent to us uncompressed
+        # otherwise the sub_filter above doesn't work. We'll compress it on the
+        # way out anyway, so clients don't lose anything by us doing this.
+        proxy_set_header Accept-Encoding "";
+      }
+    {% endif %}
     # Provide access to the competition pages under the normal prefix
     location /comp/ {
       proxy_pass       https://srobo.github.io/competition-website/comp/;


### PR DESCRIPTION
## Summary

Replaces the previous approach of un/commenting the code to change the behaviour with a configuration switch.

## Code review

Compare for example https://github.com/srobo/website/pull/271 as the way we used to do this.

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

``` diff
TASK [srobo-nginx : Copy our configuration] ***********************************
--- before: /etc/nginx/nginx.conf
+++ after: /tmp/ansible-local-.../nginx.conf
@@ -109,20 +109,8 @@
     }
 
     # During the competition we un-comment this block to override the homepage
-    # with the comeptition-specific one
-    # location = / {
-    #   proxy_pass       https://srobo.github.io/competition-website/comp/;
-    #   proxy_set_header Host srobo.github.io;
-    #
-    #   sub_filter "/competition-website/comp/" "/comp/";
-    #   sub_filter_once off;
-    #   sub_filter_last_modified on;
-    #   # Tell GitHub that we want these pages to be sent to us uncompressed
-    #   # otherwise the sub_filter above doesn't work. We'll compress it on the
-    #   # way out anyway, so clients don't lose anything by us doing this.
-    #   proxy_set_header Accept-Encoding "";
-    # }
-    # Provide access to the competition pages under the normal prefix
+    # with the competition-specific one
+        # Provide access to the competition pages under the normal prefix
     location /comp/ {
       proxy_pass       https://srobo.github.io/competition-website/comp/;
       proxy_set_header Host srobo.github.io;

changed: [monty.studentrobotics.org]
```
(yes there's some odd whitespace here, I tried fixing but it's not trivial and seems unlikely to be worth spending much time on)

### Links

Relates to https://github.com/srobo/tasks/issues/792.
