### PR TITLE
Add feedback links for SR2022

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -205,6 +205,12 @@ http {
     # Form for kit feedback
     rewrite ^/kit-feedback         https://forms.gle/2fh6dGajznkDGPtb9 redirect;
 
+    # Forms for competition cycle feedback
+    # Includes a short one for teams which is easy to tannoy, plus a slightly longer one for text-based comms (email, discord)
+    rewrite ^/feedback            https://docs.google.com/forms/d/e/1FAIpQLSeQXNw6XnATZM2LaBORIt_TgRqed3hNxpd2_2vdXXNxLY8ubA/viewform redirect;
+    rewrite ^/team-feedback       https://docs.google.com/forms/d/e/1FAIpQLSeQXNw6XnATZM2LaBORIt_TgRqed3hNxpd2_2vdXXNxLY8ubA/viewform redirect;
+    rewrite ^/supervisor-feedback https://docs.google.com/forms/d/e/1FAIpQLSc63utOabO5oBPOqgCZg-t1flOn1i5DzVC6GHcPXHEQ7_YDNg/viewform redirect;
+
     # Donation Link
     rewrite ^/donate               https://link.justgiving.com/v1/charity/donate/charityId/3118662?tipScheme=TipJar2.1&isRecurring=false&amount=10.00&reference=givingcheckout_tj21 redirect;
 


### PR DESCRIPTION
## Summary

Related to https://github.com/srobo/tasks/issues/889

## Code review

```diff
TASK [srobo-nginx : Copy our configuration] **************************************************************
--- before: /etc/nginx/nginx.conf
+++ after: /home/peterjclaw/.ansible/tmp/ansible-local-79132je220grm/tmp7tk0hgqk/nginx.conf
@@ -194,6 +194,12 @@
     # Form for kit feedback
     rewrite ^/kit-feedback         https://forms.gle/2fh6dGajznkDGPtb9 redirect;
 
+    # Forms for competition cycle feedback
+    # Includes a short one for teams which is easy to tannoy, plus a slightly longer one for text-based comms (email, discord)
+    rewrite ^/feedback            https://docs.google.com/forms/d/e/1FAIpQLSeQXNw6XnATZM2LaBORIt_TgRqed3hNxpd2_2vdXXNxLY8ubA/viewform redirect;
+    rewrite ^/team-feedback       https://docs.google.com/forms/d/e/1FAIpQLSeQXNw6XnATZM2LaBORIt_TgRqed3hNxpd2_2vdXXNxLY8ubA/viewform redirect;
+    rewrite ^/supervisor-feedback https://docs.google.com/forms/d/e/1FAIpQLSc63utOabO5oBPOqgCZg-t1flOn1i5DzVC6GHcPXHEQ7_YDNg/viewform redirect;
+
     # Donation Link
     rewrite ^/donate               https://link.justgiving.com/v1/charity/donate/charityId/3118662?tipScheme=TipJar2.1&isRecurring=false&amount=10.00&reference=givingcheckout_tj21 redirect;
 
```

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

```
$ curl -kI https://sr-vm/feedback
HTTP/2 302 
server: nginx/1.18.0 (Ubuntu)
date: Sun, 24 Apr 2022 12:11:59 GMT
content-type: text/html
content-length: 154
location: https://docs.google.com/forms/d/e/1FAIpQLSeQXNw6XnATZM2LaBORIt_TgRqed3hNxpd2_2vdXXNxLY8ubA/viewform
x-frame-options: SAMEORIGIN

$ curl -kI https://sr-vm/team-feedback
HTTP/2 302 
server: nginx/1.18.0 (Ubuntu)
date: Sun, 24 Apr 2022 12:12:02 GMT
content-type: text/html
content-length: 154
location: https://docs.google.com/forms/d/e/1FAIpQLSeQXNw6XnATZM2LaBORIt_TgRqed3hNxpd2_2vdXXNxLY8ubA/viewform
x-frame-options: SAMEORIGIN

$ curl -kI https://sr-vm/supervisor-feedback
HTTP/2 302 
server: nginx/1.18.0 (Ubuntu)
date: Sun, 24 Apr 2022 12:12:06 GMT
content-type: text/html
content-length: 154
location: https://docs.google.com/forms/d/e/1FAIpQLSc63utOabO5oBPOqgCZg-t1flOn1i5DzVC6GHcPXHEQ7_YDNg/viewform
x-frame-options: SAMEORIGIN
```

### Links

https://studentrobotics.slack.com/archives/C02BXUAK33M/p1650801609532519?thread_ts=1650800357.004159&cid=C02BXUAK33M