### PR TITLE
Add redirects for board links

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -224,6 +224,11 @@ http {
     # About page has been merged into the home page
     rewrite ^/about / redirect;
 
+    # SR Boards
+    rewrite ^/sbv4 /docs/kit/servo_board redirect;
+    rewrite ^/mbv4 /docs/kit/motor_board redirect;
+    rewrite ^/pbv4 /docs/kit/power_board redirect;
+
     location / {
       proxy_pass       https://srobo.github.io/website/;
       proxy_set_header Host srobo.github.io;

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -228,6 +228,7 @@ http {
     rewrite ^/sbv4 /docs/kit/servo_board redirect;
     rewrite ^/mbv4 /docs/kit/motor_board redirect;
     rewrite ^/pbv4 /docs/kit/power_board redirect;
+    rewrite ^/kch /docs/kit/brain_board redirect;
 
     location / {
       proxy_pass       https://srobo.github.io/website/;

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -225,10 +225,10 @@ http {
     rewrite ^/about / redirect;
 
     # SR Boards
-    rewrite ^/sbv4 /docs/kit/servo_board redirect;
+    rewrite ^/kch /docs/kit/brain_board redirect;
     rewrite ^/mbv4 /docs/kit/motor_board redirect;
     rewrite ^/pbv4 /docs/kit/power_board redirect;
-    rewrite ^/kch /docs/kit/brain_board redirect;
+    rewrite ^/sbv4 /docs/kit/servo_board redirect;
 
     location / {
       proxy_pass       https://srobo.github.io/website/;


### PR DESCRIPTION
## Summary

Add redirects for the links that are silk screened on the back of the boards.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

### Links

Closes https://github.com/srobo/website/issues/151
