### PR TITLE
Correct motor board link

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -226,7 +226,7 @@ http {
 
     # SR Boards
     rewrite ^/kch /docs/kit/brain_board redirect;
-    rewrite ^/mbv4 /docs/kit/motor_board redirect;
+    rewrite ^/mcv4 /docs/kit/motor_board redirect;
     rewrite ^/pbv4 /docs/kit/power_board redirect;
     rewrite ^/sbv4 /docs/kit/servo_board redirect;
 


### PR DESCRIPTION
## Summary

The motor board was formerly referred to as the motor controller and the short link uses this contraction.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

<!-- please do mention any other useful details -->

### Links

<!-- any useful or relevant links, including Slack discussions & documentation -->
