### PR TITLE
Specialise the web proxy role ahead of adding new roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You may wish to configure a hosts entry for easily accessing the VM, if so add
 the following line to `/etc/hosts` on the *host* machine:
 
 ```
-192.168.56.56  sr-vm sr-vm.local
+192.168.56.56  sr-proxy sr-proxy.local
 ```
 
 ## Deployment

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,16 +1,8 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/focal64"
-
-  # This name is what's looked up in the Ansible host_vars.
-  config.vm.define "sr-vm"
-
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.cpus = 4
   end
-
-  config.vm.network "private_network", ip: "192.168.56.56"
-  config.vm.hostname = "sr-vm.local"
 
   # Required so that apt cache is populated before ansible runs
   config.vm.provision "shell", privileged: true, inline: "apt-get update && apt-get upgrade -y"
@@ -19,5 +11,17 @@ Vagrant.configure(2) do |config|
     ansible.playbook = "playbook.yml"
     ansible.compatibility_mode = "2.0"
     ansible.become = true  # Run ansible as root
+
+    ansible.groups = {
+      "web-proxies" => ["sr-proxy"],
+    }
+  end
+
+  # This name is what's looked up in the Ansible host_vars.
+  config.vm.define "sr-proxy" do |web|
+    web.vm.box = "ubuntu/focal64"
+
+    web.vm.network "private_network", ip: "192.168.56.56"
+    web.vm.hostname = "sr-proxy.local"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
     ansible.become = true  # Run ansible as root
 
     ansible.groups = {
-      "web-proxies" => ["sr-proxy"],
+      "webproxies" => ["sr-proxy"],
     }
   end
 

--- a/host_vars/sr-proxy.yml
+++ b/host_vars/sr-proxy.yml
@@ -1,7 +1,7 @@
 ---
 # This is the dev VM created by Vagrant.
 
-canonical_hostname: sr-vm
+canonical_hostname: sr-proxy
 secondary_hostnames:
 
 add_hsts_header: false

--- a/hosts
+++ b/hosts
@@ -1,4 +1,4 @@
 monty.studentrobotics.org
 
-[web-proxies]
+[webproxies]
 monty.studentrobotics.org

--- a/hosts
+++ b/hosts
@@ -1,1 +1,4 @@
 monty.studentrobotics.org
+
+[web-proxies]
+monty.studentrobotics.org

--- a/playbook.yml
+++ b/playbook.yml
@@ -7,4 +7,7 @@
     - geerlingguy.ntp
     - geerlingguy.security
     - bee
+
+- hosts: web-proxies
+  roles:
     - srobo-nginx

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,6 +8,6 @@
     - geerlingguy.security
     - bee
 
-- hosts: web-proxies
+- hosts: webproxies
   roles:
     - srobo-nginx


### PR DESCRIPTION
## Summary

We're going to use this ansible config for more than just the web proxy host, which means we need to specialise the roles which aren't common to all machines. This commit does this both for ansible and Vagrant, so that our Vagrantfile can work for other machines as well.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour
