### PR TITLE
Redirect /forums to point at the Discord documentation

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -230,6 +230,9 @@ http {
     rewrite ^/pbv4 /docs/kit/power_board redirect;
     rewrite ^/sbv4 /docs/kit/servo_board redirect;
 
+    # We now use Discord instead of a self hosted forum
+    rewrite ^/forums /docs/team_admin/discord redirect;
+
     location / {
       proxy_pass       https://srobo.github.io/website/;
       proxy_set_header Host srobo.github.io;

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -83,11 +83,6 @@ http {
     #  proxy_pass https://patience.studentrobotics.org/ide/;
     #}
 
-    location /forum/ {
-      # proxy_pass https://patience.studentrobotics.org/forum/;
-      return 307 /docs/team_admin/discord;
-    }
-
     #location /docs/python/ {
     #  proxy_pass https://patience.studentrobotics.org/docs/python/;
     #}
@@ -196,6 +191,9 @@ http {
     rewrite ^/password             /userman/ permanent;
     rewrite ^/rules                /docs/rules/ permanent;
 
+    # We now use Discord instead of a self hosted forum
+    rewrite ^/forums?              /docs/team_admin/discord redirect;
+
     # The runbook has replaced trac
     rewrite ^/trac                 /runbook/ permanent;
 
@@ -229,9 +227,6 @@ http {
     rewrite ^/mcv4 /docs/kit/motor_board redirect;
     rewrite ^/pbv4 /docs/kit/power_board redirect;
     rewrite ^/sbv4 /docs/kit/servo_board redirect;
-
-    # We now use Discord instead of a self hosted forum
-    rewrite ^/forums /docs/team_admin/discord redirect;
 
     location / {
       proxy_pass       https://srobo.github.io/website/;


### PR DESCRIPTION
## Summary

We no longer use our own forums, instead a Discord server.
## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

```
$ curl -Ik https://sr-vm/forum ; curl -Ik https://sr-vm/forum/ ; curl -Ik https://sr-vm/forums ; curl -Ik https://sr-vm/forums/
HTTP/2 302 
server: nginx/1.18.0 (Ubuntu)
date: Sat, 22 Oct 2022 09:19:24 GMT
content-type: text/html
content-length: 154
location: https://sr-vm/docs/team_admin/discord
x-frame-options: SAMEORIGIN

HTTP/2 302 
server: nginx/1.18.0 (Ubuntu)
date: Sat, 22 Oct 2022 09:19:25 GMT
content-type: text/html
content-length: 154
location: https://sr-vm/docs/team_admin/discord
x-frame-options: SAMEORIGIN

HTTP/2 302 
server: nginx/1.18.0 (Ubuntu)
date: Sat, 22 Oct 2022 09:19:25 GMT
content-type: text/html
content-length: 154
location: https://sr-vm/docs/team_admin/discord
x-frame-options: SAMEORIGIN

HTTP/2 302 
server: nginx/1.18.0 (Ubuntu)
date: Sat, 22 Oct 2022 09:19:25 GMT
content-type: text/html
content-length: 154
location: https://sr-vm/docs/team_admin/discord
x-frame-options: SAMEORIGIN
```

``` diff
TASK [srobo-nginx : Copy our configuration] *************************************
--- before: /etc/nginx/nginx.conf
+++ after: /home/peterjclaw/.ansible/tmp/ansible-local-1361047yku9np0/tmp93h90qmn/nginx.conf
@@ -74,11 +74,6 @@
     #  proxy_pass https://patience.studentrobotics.org/ide/;
     #}
 
-    location /forum/ {
-      # proxy_pass https://patience.studentrobotics.org/forum/;
-      return 307 /docs/team_admin/discord;
-    }
-
     #location /docs/python/ {
     #  proxy_pass https://patience.studentrobotics.org/docs/python/;
     #}
@@ -173,6 +168,9 @@
     rewrite ^/password             /userman/ permanent;
     rewrite ^/rules                /docs/rules/ permanent;
 
+    # We now use Discord instead of a self hosted forum
+    rewrite ^/forums?              /docs/team_admin/discord redirect;
+
     # The runbook has replaced trac
     rewrite ^/trac                 /runbook/ permanent;
 

changed: [monty.studentrobotics.org]
```
