### PR TITLE
Add a redirect to the SR2023 microgames

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -97,6 +97,9 @@ http {
       proxy_set_header Host srobo.github.io;
     }
 
+    # SR2023 microgames
+    rewrite ^/microgames           https://docs.google.com/document/d/1jj7DP0gXUDItHEe77ABc5cyV82qqbA_7SYDgiihUbxA/edit redirect;
+
     #location /userman/ {
     #  proxy_pass https://patience.studentrobotics.org/userman/;
     #}


### PR DESCRIPTION
## Summary

![:ronseal:](https://user-images.githubusercontent.com/336212/197330180-3ae84632-8545-4ba9-bd4f-5a3f0f3b4961.png)

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

``` diff
TASK [srobo-nginx : Copy our configuration] ************************************************************************************************
--- before: /etc/nginx/nginx.conf
+++ after: /home/peterjclaw/.ansible/tmp/ansible-local-121676vsucz1fu/tmpr1x2z3d9/nginx.conf
@@ -88,6 +88,9 @@
       proxy_set_header Host srobo.github.io;
     }
 
+    # SR2023 microgames
+    rewrite ^/microgames           https://docs.google.com/document/d/1jj7DP0gXUDItHEe77ABc5cyV82qqbA_7SYDgiihUbxA/edit redirect;
+
     #location /userman/ {
     #  proxy_pass https://patience.studentrobotics.org/userman/;
     #}

changed: [monty.studentrobotics.org]
```

### Links

https://studentrobotics.slack.com/archives/CBP7UL6RG/p1666402018012279