### PR TITLE
Add reverse proxying to checklists

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -178,6 +178,11 @@ http {
       proxy_pass       https://srobo.github.io/srawn/;
       proxy_set_header Host srobo.github.io;
     }
+    
+    location /checklists/ {
+      proxy_pass       https://srobo.github.io/checklists/;
+      proxy_set_header Host srobo.github.io;
+    }
 
     # GitHub has replaced various development related services which used to be
     # on saffron.


### PR DESCRIPTION
## Summary

Add proxying of `/checklists`.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

### Links

https://srobo.github.io/checklists/
