### PR TITLE
Add a redirect for `/links` to the homepage

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -225,6 +225,9 @@ http {
     # About page has been merged into the home page
     rewrite ^/about / redirect;
 
+    # srobo.org/links is on our business cards
+    rewrite ^/links / redirect;
+
     # SR Boards
     rewrite ^/kch /docs/kit/brain_board redirect;
     rewrite ^/mcv4 /docs/kit/motor_board redirect;


### PR DESCRIPTION
## Summary

srobo.org/links is going to be on our new business cards. We're currently undecided if we want to display a separate cut down list of links, or just redirect to the homepage. This commit adds the redirect so we can easily change our minds later.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour


### Links

https://github.com/srobo/website/issues/483
