### PR TITLE
Add public URL for the code submitter

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -99,9 +99,9 @@ http {
     #  proxy_pass https://patience.studentrobotics.org/userman/;
     #}
 
-    #location /code-submitter/ {
-    #  proxy_pass https://patience.studentrobotics.org/code-submitter/;
-    #}
+    location /code-submitter/ {
+      proxy_pass https://competitorsvcs.studentrobotics.org/code-submitter/;
+    }
 
     #location /robogit/ {
     #  proxy_pass https://patience.studentrobotics.org/robogit/;
@@ -178,7 +178,7 @@ http {
       proxy_pass       https://srobo.github.io/srawn/;
       proxy_set_header Host srobo.github.io;
     }
-    
+
     location /checklists/ {
       proxy_pass       https://srobo.github.io/checklists/;
       proxy_set_header Host srobo.github.io;


### PR DESCRIPTION
## Summary

The code submitter from #30 needs to be given a public URL on `studentrobotics.org`, so it's better for competitors to find.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

<!-- please do mention any other useful details -->

### Links

<!-- any useful or relevant links, including Slack discussions & documentation -->
