### PR TITLE
Override host when talking to competitor services

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -101,6 +101,9 @@ http {
 
     location /code-submitter/ {
       proxy_pass https://competitorsvcs.studentrobotics.org/code-submitter/;
+
+      # Don't pass through host header, else we end up in a redirect loop
+      proxy_set_header Host competitorsvcs.studentrobotics.org;
     }
 
     #location /robogit/ {


### PR DESCRIPTION
## Summary

Explicitly send the `Host` header when talking to competitorsvcs VM.

The competitor services VM has a `location` to ensure it's being talked to at the correct hostname. Therefore, we need to explicitly set the `Host` header to the correct value, otherwise `nginx` passes through `studentrobotics.org`.

## Code review

### Testing

- [x] applied the configuration ~~locally~~ on production
- [x] manually validated the new behaviour

<!-- please do mention any other useful details -->

### Links

<!-- any useful or relevant links, including Slack discussions & documentation -->
