### PR TITLE
Remove dead patience proxying

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -79,14 +79,6 @@ http {
     proxy_set_header X-Forwarded-Proto  https;
     proxy_set_header Host               $host;
 
-    #location /ide/ {
-    #  proxy_pass https://patience.studentrobotics.org/ide/;
-    #}
-
-    #location /docs/python/ {
-    #  proxy_pass https://patience.studentrobotics.org/docs/python/;
-    #}
-
     location /docs/ {
       proxy_pass       https://srobo.github.io/docs/;
       proxy_set_header Host srobo.github.io;
@@ -95,21 +87,9 @@ http {
     # SR2023 microgames
     rewrite ^/microgames           https://docs.google.com/document/d/1jj7DP0gXUDItHEe77ABc5cyV82qqbA_7SYDgiihUbxA/edit redirect;
 
-    #location /userman/ {
-    #  proxy_pass https://patience.studentrobotics.org/userman/;
-    #}
-
     location /code-submitter/ {
       proxy_pass https://competitorsvcs.studentrobotics.org/code-submitter/;
     }
-
-    #location /robogit/ {
-    #  proxy_pass https://patience.studentrobotics.org/robogit/;
-    #}
-
-    #location /robogit-ro/ {
-    #  proxy_pass https://patience.studentrobotics.org/robogit-ro/;
-    #}
 
     location /comp-api/ {
       proxy_pass https://srcomp.studentrobotics.org/comp-api/;
@@ -150,19 +130,6 @@ http {
       proxy_pass       https://srobo.github.io/competition-website/;
       proxy_set_header Host srobo.github.io;
     }
-
-    # Disable custom media consent endpoint
-    #location /mediaconsent/ {
-    #  proxy_pass https://patience.studentrobotics.org/mediaconsent/;
-    #}
-
-    #location /tickets/ {
-    #  proxy_pass https://patience.studentrobotics.org/tickets/;
-    #}
-
-    #location /ticket-api/ {
-    #  proxy_pass https://patience.studentrobotics.org/ticket-api/;
-    #}
 
     location /style/ {
       proxy_pass       https://srobo.github.io/style/;


### PR DESCRIPTION
## Summary

We've not used these services for a long time (several competition cycles), so there's very little benefit in keeping the dead code around.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour
