### PR TITLE
Ensure the code submitter sees the correct domain

### DIFF
--- a/host_vars/competitorsvcs.studentrobotics.org.yml
+++ b/host_vars/competitorsvcs.studentrobotics.org.yml
@@ -1,6 +1,7 @@
 ---
 canonical_hostname: competitorsvcs.studentrobotics.org
 secondary_hostnames:
+  - studentrobotics.org
 
 add_hsts_header: true
 certbot_certs:

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -101,9 +101,6 @@ http {
 
     location /code-submitter/ {
       proxy_pass https://competitorsvcs.studentrobotics.org/code-submitter/;
-
-      # Don't pass through host header, else we end up in a redirect loop
-      proxy_set_header Host competitorsvcs.studentrobotics.org;
     }
 
     #location /robogit/ {


### PR DESCRIPTION
## Summary

The code submitter always uses absolute URLs (including domain). It only sees the competitorsvcs hostname, so uses this for the URLs. Now we allow the competitorsvcs VM to accept traffic with a `studentrobotics.org` host

## Code review

### Testing

- [x] already running on production
- [x] manually validated the new behaviour

### Links

