### PR TITLE
Add SR2023 Helpdesk system to proxy

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -130,6 +130,11 @@ http {
       proxy_pass       https://srobo.github.io/competition-website/;
       proxy_set_header Host srobo.github.io;
     }
+    
+    location /helpdesk/ {
+      proxy_pass       https://srhelpdesk.fly.dev/;
+      proxy_set_header Host srhelpdesk.fly.dev;
+    }
 
     location /style/ {
       proxy_pass       https://srobo.github.io/style/;

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -134,6 +134,7 @@ http {
     location /helpdesk/ {
       proxy_pass       https://srhelpdesk.fly.dev/;
       proxy_set_header Host srhelpdesk.fly.dev;
+      proxy_ssl_server_name on;     # fly.dev requires SNI for connections
     }
 
     location /style/ {


### PR DESCRIPTION
## Summary

Add the helpdesk system for this year's comp to the proxy.

NB: The sign up is still being built. System is MVP currently, we're planning to work on it a bit more before the comp.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

<!-- please do mention any other useful details -->

### Links

<!-- any useful or relevant links, including Slack discussions & documentation -->
