### PR TITLE
Revert "Enable competition mode homepage"

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -12,7 +12,7 @@ certbot_create_standalone_stop_services:
 
 # Override serving of the root url to be the competition mode homepage instead
 # of the normal one.
-enable_competition_homepage: true
+enable_competition_homepage: false
 
 
 firewall_allowed_tcp_ports:


### PR DESCRIPTION
This reverts commit f6f82c78ab278e506895d9c0cbe390bd56a2c47a.

Fixes https://github.com/srobo/tasks/issues/1145

PR for easier shipping at the time.
Don't forget to also apply the config.