### PR TITLE
Add /safeguarding link

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -189,6 +189,7 @@ http {
 
     # Volunteering Links
     rewrite ^/join                 https://docs.google.com/forms/d/e/1FAIpQLSfGZir0z9ge3fw89xtVNZFmAP0jH7wh5cFmZHuYKDXRGJrYUQ/viewform redirect;
+    rewrite ^/safeguarding         https://opsmanual.studentrobotics.org/about-the-charity/safeguarding redirect;
 
     # We have renamed the news section to blog
     rewrite ^/news/(.*) /blog/$1/ redirect;


### PR DESCRIPTION
Fixes https://github.com/srobo/website/issues/504

## Summary

Can be used in the volunteer onboarding presentation and to make it easier to tell new volunteers at events where to find a digital copy of the safeguarding policy

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

<!-- please do mention any other useful details -->

### Links

<!-- any useful or relevant links, including Slack discussions & documentation -->
