### PR TITLE
Add some security headers

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -25,7 +25,7 @@ http {
   ;
 
   {% if add_hsts_header %}
-    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
   {% endif %}
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "SAMEORIGIN" always;

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -27,6 +27,7 @@ http {
   {% if add_hsts_header %}
     add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload" always;
   {% endif %}
+  add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "SAMEORIGIN" always;
 
   # Set an explicitly empty Referrer-Policy. We're not hosting anything which is

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -29,6 +29,12 @@ http {
   {% endif %}
   add_header X-Frame-Options "SAMEORIGIN" always;
 
+  # Set an explicitly empty Referrer-Policy. We're not hosting anything which is
+  # likely to be particularly privacy sensitive, so we can tell browsers to do
+  # whatever they would otherwise do by default. Setting this explictly confirms
+  # we've considered rather than just omitted this.
+  add_header Referrer-Policy "''" always;
+
   # HTTPS certificates
   {% if certbot_create_if_missing %}
     {% for certs in certbot_certs %}


### PR DESCRIPTION
## Summary

Add a couple of security headers. We're basically fine without these, but they're cheap to add and shut up some of the warnings we otherwise get on the various online checkers.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

### Links

https://scotthelme.co.uk/a-new-security-header-referrer-policy/
https://scotthelme.co.uk/hardening-your-http-response-headers/#x-content-type-options
https://securityheaders.com/?followRedirects=on&hide=on&q=studentrobotics.org
https://observatory.mozilla.org/analyze/studentrobotics.org
