### PR TITLE
Drop Referrer-Policy which doesn't work like I'd hoped

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -30,11 +30,11 @@ http {
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "SAMEORIGIN" always;
 
-  # Set an explicitly empty Referrer-Policy. We're not hosting anything which is
-  # likely to be particularly privacy sensitive, so we can tell browsers to do
-  # whatever they would otherwise do by default. Setting this explictly confirms
-  # we've considered rather than just omitted this.
-  add_header Referrer-Policy "''" always;
+  # Don't set a Referrer-Policy. We're not hosting anything which is likely to
+  # be particularly privacy sensitive, so we'd ideally tell browsers to make
+  # their own decision. Unfortunately there doesn't seem to be a way to do that.
+  # In theory returning an empty value should work, however there doesn't seem
+  # to be way to tell nginx to do so.
 
   # HTTPS certificates
   {% if certbot_create_if_missing %}


### PR DESCRIPTION
## Summary

Don't set a Referrer-Policy. We're not hosting anything which is likely to be particularly privacy sensitive, so we'd ideally tell browsers to make their own decision. Unfortunately there doesn't seem to be a way to do that. In theory returning an empty value should work, however there doesn't seem to be way to tell `nginx` to do so.

## Code review

### Testing

Already applied, PR for visibility.
