### PR TITLE
Enable OCSP stapling for our TLS certificates

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -39,8 +39,11 @@ http {
   # HTTPS certificates
   {% if certbot_create_if_missing %}
     {% for certs in certbot_certs %}
-      ssl_certificate     /etc/letsencrypt/live/{{ certs.domains[0] }}/fullchain.pem;
-      ssl_certificate_key /etc/letsencrypt/live/{{ certs.domains[0] }}/privkey.pem;
+      ssl_certificate         /etc/letsencrypt/live/{{ certs.domains[0] }}/fullchain.pem;
+      ssl_certificate_key     /etc/letsencrypt/live/{{ certs.domains[0] }}/privkey.pem;
+      ssl_stapling            on;
+      ssl_stapling_verify     on;
+      ssl_trusted_certificate /etc/letsencrypt/live/{{ certs.domains[0] }}/chain.pem;
     {% endfor %}
   {% else %}
     ssl_certificate     /etc/ssl/certs/ssl-cert-snakeoil.pem;


### PR DESCRIPTION
## Summary

This should save clients a round trip to the CA on their first page-load of our site, improving performance.

## Code review

### Testing

Already applied in production, validated via HTTPS analysis tools.

### Links

https://www.ssllabs.com/ssltest/analyze.html?d=studentrobotics.org
https://www.immuniweb.com/ssl/studentrobotics.org/MJ0vClEy/
