### PR TITLE
Limit hsts to known https connections

### DIFF
--- a/roles/competitor-services-nginx/templates/nginx.conf
+++ b/roles/competitor-services-nginx/templates/nginx.conf
@@ -24,9 +24,6 @@ http {
     image/x-icon
   ;
 
-  {% if add_hsts_header %}
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-  {% endif %}
   add_header X-Frame-Options "SAMEORIGIN" always;
 
   # HTTPS certificates
@@ -72,6 +69,10 @@ http {
     listen         [::]:443 ssl;
     server_name    {{ canonical_hostname }} {{ secondary_hostnames }};
     root           /var/www;
+
+    {% if add_hsts_header %}
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    {% endif %}
 
     proxy_pass_request_headers on;
     proxy_set_header X-Real-IP          $remote_addr;

--- a/roles/competitor-services-nginx/templates/nginx.conf
+++ b/roles/competitor-services-nginx/templates/nginx.conf
@@ -25,7 +25,7 @@ http {
   ;
 
   {% if add_hsts_header %}
-    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
   {% endif %}
   add_header X-Frame-Options "SAMEORIGIN" always;
 

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -24,9 +24,6 @@ http {
     image/x-icon
   ;
 
-  {% if add_hsts_header %}
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-  {% endif %}
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "SAMEORIGIN" always;
 
@@ -82,6 +79,10 @@ http {
     listen         [::]:443 ssl;
     server_name    {{ canonical_hostname }} {{ secondary_hostnames }};
     root           /var/www;
+
+    {% if add_hsts_header %}
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    {% endif %}
 
     proxy_pass_request_headers on;
     proxy_set_header X-Real-IP          $remote_addr;


### PR DESCRIPTION
## Summary

Some HTTPS tooling (most notably https://hstspreload.org/) warn about emitting HSTS headers on non-HTTPS connections as it has no effect. While it's slightly cleaner to have this declared upfront on all connections, restricting it to just the right places is more correct.

This change also means that we don't emit the header for other domains which happen to point at these servers (whether that's our own domains falling back to them or other ones), which also feels slightly more correct.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

### Links

https://hstspreload.org/?domain=studentrobotics.org