### PR TITLE
Make our upstream proxies configurable

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,6 +10,10 @@ certbot_create_standalone_stop_services:
  - nginx
 
 
+# We typically only host the public SRComp machine around the time of the
+# competition. It is required for the competition pages, including the
+# competition homepage.
+enable_srcomp_proxy: false
 # Override serving of the root url to be the competition mode homepage instead
 # of the normal one.
 enable_competition_homepage: false

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -18,6 +18,9 @@ enable_srcomp_proxy: false
 # of the normal one.
 enable_competition_homepage: false
 
+# We typically only host the competitor services for the duration of the
+# competition year.
+enable_competitor_services_proxy: true
 
 firewall_allowed_tcp_ports:
  - "22"

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -101,25 +101,28 @@ http {
       proxy_pass https://competitorsvcs.studentrobotics.org/code-submitter/;
     }
 
-    location /comp-api/ {
-      proxy_pass https://srcomp.studentrobotics.org/comp-api/;
-    }
-
-    # During the competition we un-comment this block to override the homepage
-    # with the competition-specific one
-    {% if enable_competition_homepage %}
-      location = / {
-        proxy_pass       https://srobo.github.io/competition-website/comp/;
-        proxy_set_header Host srobo.github.io;
-
-        sub_filter "/competition-website/comp/" "/comp/";
-        sub_filter_once off;
-        sub_filter_last_modified on;
-        # Tell GitHub that we want these pages to be sent to us uncompressed
-        # otherwise the sub_filter above doesn't work. We'll compress it on the
-        # way out anyway, so clients don't lose anything by us doing this.
-        proxy_set_header Accept-Encoding "";
+    {% if enable_srcomp_proxy %}
+      # When the proxied service is not available NGINX will refuse to start.
+      location /comp-api/ {
+        proxy_pass https://srcomp.studentrobotics.org/comp-api/;
       }
+
+      # During the competition we un-comment this block to override the homepage
+      # with the competition-specific one
+      {% if enable_competition_homepage %}
+        location = / {
+          proxy_pass       https://srobo.github.io/competition-website/comp/;
+          proxy_set_header Host srobo.github.io;
+
+          sub_filter "/competition-website/comp/" "/comp/";
+          sub_filter_once off;
+          sub_filter_last_modified on;
+          # Tell GitHub that we want these pages to be sent to us uncompressed
+          # otherwise the sub_filter above doesn't work. We'll compress it on the
+          # way out anyway, so clients don't lose anything by us doing this.
+          proxy_set_header Accept-Encoding "";
+        }
+      {% endif %}
     {% endif %}
     # Provide access to the competition pages under the normal prefix
     location /comp/ {

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -97,9 +97,12 @@ http {
     # SR2023 microgames
     rewrite ^/microgames           https://docs.google.com/document/d/1jj7DP0gXUDItHEe77ABc5cyV82qqbA_7SYDgiihUbxA/edit redirect;
 
-    location /code-submitter/ {
-      proxy_pass https://competitorsvcs.studentrobotics.org/code-submitter/;
-    }
+    {% if enable_competitor_services_proxy %}
+      # When the proxied service is not available NGINX will refuse to start.
+      location /code-submitter/ {
+        proxy_pass https://competitorsvcs.studentrobotics.org/code-submitter/;
+      }
+    {% endif %}
 
     {% if enable_srcomp_proxy %}
       # When the proxied service is not available NGINX will refuse to start.


### PR DESCRIPTION
## Summary

This is required as NGINX will refuse to start if the upstream services cannot be resolved.

Currently the SRComp proxy is not around, meaning that nginx is in a fragile state. It's had the offending lines manually commented out; this PR makes the relevant parts of the config configurable and sets the values we currently want.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

### Links

Alternative approach to #51, though they could be combined.
