### PR TITLE
Use variables to make our upstream proxies lazily resolved

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -98,11 +98,13 @@ http {
     rewrite ^/microgames           https://docs.google.com/document/d/1jj7DP0gXUDItHEe77ABc5cyV82qqbA_7SYDgiihUbxA/edit redirect;
 
     location /code-submitter/ {
-      proxy_pass https://competitorsvcs.studentrobotics.org/code-submitter/;
+      set $competitorsvcs 'competitorsvcs.studentrobotics.org';
+      proxy_pass https://$competitorsvcs/code-submitter/;
     }
 
     location /comp-api/ {
-      proxy_pass https://srcomp.studentrobotics.org/comp-api/;
+      set $srcomp 'srcomp.studentrobotics.org';
+      proxy_pass https://$srcomp/comp-api/;
     }
 
     # During the competition we un-comment this block to override the homepage


### PR DESCRIPTION
## Summary

This avoids issues where NGINX will refuse to start if there are no DNS entries for these servers, as is the case over the summer while we don't run them. However it does so in a manner which won't inherently catch errors when the upstreams are present.

Since we expect that nginx will be restarted (or at least reloaded) regularly as part of TLS certificate updates, this trade-off is accepted for overall reliability.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

### Links

Alternative approach to #50, though they could be combined.
