### PR TITLE
Initial testing-mode MTA-STS policy

### DIFF
--- a/roles/srobo-nginx/files/well-known-mta-sts.txt
+++ b/roles/srobo-nginx/files/well-known-mta-sts.txt
@@ -1,0 +1,8 @@
+version: STSv1
+mode: testing
+mx: aspmx.l.google.com
+mx: alt1.aspmx.l.google.com
+mx: aspmx3.googlemail.com
+mx: aspmx2.googlemail.com
+mx: alt2.aspmx.l.google.com
+max_age: 604800

--- a/roles/srobo-nginx/tasks/main.yml
+++ b/roles/srobo-nginx/tasks/main.yml
@@ -11,6 +11,23 @@
     pkg: ssl-cert
   when: not certbot_create_if_missing
 
+- name: Create .well-known directory
+  file:
+    path: /var/www/.well-known
+    state: directory
+    owner: www-data
+    mode: "755"
+  notify:
+    Reload nginx
+
+- name: Copy .well-known/mta-sts.txt
+  copy:
+    src: files/well-known-mta-sts.txt
+    dest: /var/www/.well-known/mta-sts.txt
+    mode: "0644"
+  notify:
+    Reload nginx
+
 - name: Copy dhparam.txt
   copy:
     src: files/dhparam.txt

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -89,6 +89,11 @@ http {
     proxy_set_header X-Forwarded-Proto  https;
     proxy_set_header Host               $host;
 
+    location /.well-known/ {
+      root            /var/www;
+      error_page      403 404 =404 /404.html;
+    }
+
     location /docs/ {
       proxy_pass       https://srobo.github.io/docs/;
       proxy_set_header Host srobo.github.io;


### PR DESCRIPTION
## Summary

Allows us to explore using MTA-STS for privacy protection on incoming emails, which _might_ help our deliverability...? Seems tenuous, but given how much magic email deliverability is who knows :shrug:.

The content of the file comes from Google's diagnostic page at https://admin.google.com/u/1/ac/apps/cs/diagnostic as well as matching what other sources suggest it should contain.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

Have manually checked the hosted file under `.well-known`, haven't been able to test the file's syntax.

Output from `./scripts/apply --check --diff`:
``` diff
TASK [srobo-nginx : Create .well-known directory]
--- before
+++ after
@@ -1,4 +1,4 @@
 {
     "path": "/var/www/.well-known",
-    "state": "absent"
+    "state": "directory"
 }

changed: [monty.studentrobotics.org]

TASK [srobo-nginx : Copy .well-known/mta-sts.txt]
--- before
+++ after: /home/srobo/ansible/roles/srobo-nginx/files/well-known-mta-sts.txt
@@ -0,0 +1,8 @@
+version: STSv1
+mode: testing
+mx: aspmx.l.google.com
+mx: alt1.aspmx.l.google.com
+mx: aspmx3.googlemail.com
+mx: aspmx2.googlemail.com
+mx: alt2.aspmx.l.google.com
+max_age: 604800

changed: [monty.studentrobotics.org]

TASK [srobo-nginx : Copy dhparam.txt]
ok: [monty.studentrobotics.org]

TASK [srobo-nginx : Copy our configuration]
--- before: /etc/nginx/nginx.conf
+++ after: /home/peter/.ansible/tmp/ansible-local-1224588ienwr8p/tmpvq_ii7hw/nginx.conf
@@ -79,6 +79,11 @@
     proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto  https;
     proxy_set_header Host               $host;
+
+    location /.well-known/ {
+      root            /var/www;
+      error_page      403 404 =404 /404.html;
+    }
 
     location /docs/ {
       proxy_pass       https://srobo.github.io/docs/;

changed: [monty.studentrobotics.org]

TASK [srobo-nginx : Ensure nginx is running]
ok: [monty.studentrobotics.org]

RUNNING HANDLER [srobo-nginx : Reload nginx]
changed: [monty.studentrobotics.org]
```

### Links

- https://www.ncsc.gov.uk/collection/email-security-and-anti-spoofing/using-mta-sts-to-protect-the-privacy-of-your-emails
- https://emailsecuritycheck.service.ncsc.gov.uk/results?domain=studentrobotics.org&code=1ac42da#dkim
- https://support.google.com/a/answer/9261504?hl=en&ref_topic=9261406
