### PR TITLE
Add the discord-gated-entry bot

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -20,3 +20,4 @@
   roles:
     - competitor-services-nginx
     - code-submitter
+    - discord-gated-entry

--- a/roles/discord-gated-entry/README.md
+++ b/roles/discord-gated-entry/README.md
@@ -1,0 +1,5 @@
+# Discord Gated Entry
+
+A Bot for gating entry to a Discord server.
+
+This is a deployment of <https://github.com/srobo/discord-gated-entry>.

--- a/roles/discord-gated-entry/handlers/main.yml
+++ b/roles/discord-gated-entry/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart discord-gated-entry
+  service:
+    name: discord-gated-entry
+    state: restarted

--- a/roles/discord-gated-entry/tasks/main.yml
+++ b/roles/discord-gated-entry/tasks/main.yml
@@ -1,0 +1,63 @@
+- name: Install virtualenv system dependencies
+  apt:
+    pkg:
+      - python3-virtualenv
+      - python3-wheel
+
+- name: Create user
+  user:
+    name: discord
+    shell: /bin/nologin
+    state: present
+    create_home: false
+
+- name: Create install directory
+  file:
+    path: "{{ install_dir }}"
+    state: directory
+    owner: discord
+    mode: "755"
+
+- name: Download
+  git:
+    repo: https://github.com/srobo/discord-gated-entry
+    dest: "{{ install_dir }}"
+    force: true
+    version: 476a9c942f580e2950048c2b95e15429cb0ae33d
+  notify:
+    Restart discord-gated-entry
+  register: discord_gated_entry_repo
+  become_user: discord
+
+- name: Bootstrap environment file
+  copy:
+    content: ""
+    dest: "{{ install_dir }}/.env"
+    force: false
+    mode: "0600"
+    owner: discord
+  notify:
+    Restart discord-gated-entry
+
+- name: Install virtual environment
+  pip:
+    virtualenv: "{{ venv_dir }}"
+    requirements: "{{ install_dir }}/requirements.txt"
+  notify:
+    Restart discord-gated-entry
+  become_user: discord
+  when: discord_gated_entry_repo.changed  # noqa: no-handler - Use a handler to ensure execution order
+
+- name: Install systemd service
+  template:
+    src: discord-gated-entry.service
+    dest: /etc/systemd/system/discord-gated-entry.service
+    mode: "0644"
+  notify:
+    Restart discord-gated-entry
+
+- name: Enable service
+  service:
+    name: discord-gated-entry
+    state: started
+    enabled: true

--- a/roles/discord-gated-entry/templates/discord-gated-entry.service
+++ b/roles/discord-gated-entry/templates/discord-gated-entry.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Discord bot for gated entry
+After=network.target
+
+[Service]
+User=discord
+
+Type=simple
+
+WorkingDirectory={{ install_dir }}
+RuntimeDirectory=discord-gated-entry
+
+ExecStart=/srv/discord-gated-entry/venv/bin/python main.py
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/discord-gated-entry/vars/main.yml
+++ b/roles/discord-gated-entry/vars/main.yml
@@ -1,0 +1,2 @@
+install_dir: /srv/discord-gated-entry
+venv_dir: "{{ install_dir }}/venv"


### PR DESCRIPTION
## Summary

This was actually already hosted from previous years, this is adding it to ansible.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

This configuration has been run in prod in order to deploy the updated bot for SR2024. Not something I want to make a habit of, but given that we wanted to test the interactions with Discord and needed to deploy it anyway (and the SR2024 Discord wasn't yet open to competitors), this seemed expedient.

### Links

https://github.com/srobo/discord-gated-entry
