### PR TITLE
Pass through the full request_uri to these proxied services

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -122,7 +122,7 @@ http {
         # Use a variable to trick it into connecting lazily and thus always
         # starting up, even if in a degraded mode.
         set $competitorsvcs '{{ competitor_services_proxy_hostname }}';
-        proxy_pass https://$competitorsvcs/code-submitter/;
+        proxy_pass https://$competitorsvcs$request_uri;
         # Note: don't set a Host header as we want the code-submitter to use our
         # public hostname, not the hostname of the underlying machine.
       }
@@ -134,7 +134,7 @@ http {
         # Use a variable to trick it into connecting lazily and thus always
         # starting up, even if in a degraded mode.
         set $srcomp '{{ srcomp_proxy_hostname }}';
-        proxy_pass https://$srcomp/comp-api/;
+        proxy_pass https://$srcomp$request_uri;
       }
 
       # During the competition we un-comment this block to override the homepage


### PR DESCRIPTION
## Summary

It turns out that when proxy_pass is given a value with variables in then it always proxies to exactly that value, without any of the normal appending of the rest of the path or query. This means we need to explicitly pass the request uri through in such cases.

Exactly what this means for processing of the content returned from the proxied host is somewhat unclear, however testing of the code-submitter suggests at least that its redirects work as desired.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

### Links

https://discord.com/channels/1154145712943153252/1154145715518459950/1207444719655849994

Note: given the urgency here and that this is currently broken I've already applied this fix in prod.
