### PR TITLE
Add hosting of the Discord Logs Uploader bot

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -21,3 +21,4 @@
     - competitor-services-nginx
     - code-submitter
     - discord-gated-entry
+    - discord-logs-uploader

--- a/roles/discord-logs-uploader/README.md
+++ b/roles/discord-logs-uploader/README.md
@@ -1,0 +1,5 @@
+# Discord Gated Entry
+
+A Bot for gating entry to a Discord server.
+
+This is a deployment of <https://github.com/WillB97/discord-logs-uploader>.

--- a/roles/discord-logs-uploader/handlers/main.yml
+++ b/roles/discord-logs-uploader/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart discord-logs-uploader
+  service:
+    name: discord-logs-uploader
+    state: restarted

--- a/roles/discord-logs-uploader/tasks/main.yml
+++ b/roles/discord-logs-uploader/tasks/main.yml
@@ -1,0 +1,63 @@
+- name: Install virtualenv system dependencies
+  apt:
+    pkg:
+      - python3-virtualenv
+      - python3-wheel
+
+- name: Create user
+  user:
+    name: discord-logs-uploader
+    shell: /bin/nologin
+    state: present
+    create_home: false
+
+- name: Create install directory
+  file:
+    path: "{{ install_dir }}"
+    state: directory
+    owner: discord-logs-uploader
+    mode: "755"
+
+- name: Download
+  git:
+    repo: https://github.com/WillB97/discord-logs-uploader
+    dest: "{{ install_dir }}"
+    force: true
+    version: 87002f6472e284d6bd446fadb679d33fca102761
+  notify:
+    Restart discord-logs-uploader
+  register: discord_gated_entry_repo
+  become_user: discord-logs-uploader
+
+- name: Bootstrap environment file
+  copy:
+    content: ""
+    dest: "{{ install_dir }}/.env"
+    force: false
+    mode: "0600"
+    owner: discord-logs-uploader
+  notify:
+    Restart discord-logs-uploader
+
+- name: Install virtual environment
+  pip:
+    virtualenv: "{{ venv_dir }}"
+    requirements: "{{ install_dir }}/requirements.txt"
+  notify:
+    Restart discord-logs-uploader
+  become_user: discord-logs-uploader
+  when: discord_gated_entry_repo.changed  # noqa: no-handler - Use a handler to ensure execution order
+
+- name: Install systemd service
+  template:
+    src: discord-logs-uploader.service
+    dest: /etc/systemd/system/discord-logs-uploader.service
+    mode: "0644"
+  notify:
+    Restart discord-logs-uploader
+
+- name: Enable service
+  service:
+    name: discord-logs-uploader
+    state: started
+    enabled: true

--- a/roles/discord-logs-uploader/templates/discord-logs-uploader.service
+++ b/roles/discord-logs-uploader/templates/discord-logs-uploader.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Discord bot for sending logs to teams via their Discord channels
+After=network.target
+
+[Service]
+User=discord-logs-uploader
+
+Type=simple
+
+WorkingDirectory={{ install_dir }}
+RuntimeDirectory=discord-logs-uploader
+
+ExecStart=/srv/discord-logs-uploader/venv/bin/python discord_logs_uploader.py
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/discord-logs-uploader/vars/main.yml
+++ b/roles/discord-logs-uploader/vars/main.yml
@@ -1,0 +1,2 @@
+install_dir: /srv/discord-logs-uploader
+venv_dir: "{{ install_dir }}/venv"


### PR DESCRIPTION
## Summary

I'm not sure where this runs currently, if at all, however as we need it to share the friendlies logs and will need it for the Virtual Competition we should add it here.

This is pretty much a copy/paste of the role for the gated-entry bot.

## Code review

### Testing

- [x] applied the configuration locally
- [ ] manually validated the new behaviour

This applies cleanly locally, however I'm not sure how to test it in prod as that will need to connect to actual Discord.

### Links

https://github.com/WillB97/discord-logs-uploader
