### PR TITLE
Remove competition homepage

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -21,7 +21,7 @@ enable_srcomp_proxy: true
 srcomp_proxy_hostname: srcomp.studentrobotics.org
 # Override serving of the root url to be the competition mode homepage instead
 # of the normal one.
-enable_competition_homepage: true
+enable_competition_homepage: false
 
 # We typically only host the competitor services for the duration of the
 # competition year.


### PR DESCRIPTION
## Summary

Put the homepage back in non-competition mode

https://github.com/srobo/tasks/issues/1302

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

<!-- please do mention any other useful details -->

### Links

<!-- any useful or relevant links, including Slack discussions & documentation -->
