### PR TITLE
Merge config update Mythic have applied in prod

### DIFF
--- a/roles/competitor-services-nginx/templates/nginx.conf
+++ b/roles/competitor-services-nginx/templates/nginx.conf
@@ -79,6 +79,11 @@ http {
     proxy_set_header X-Forwarded-Proto  https;
     proxy_set_header Host               $host;
 
+    # Stop abusive ClaudeBot (via Mythic)
+    if ($http_user_agent ~* (ClaudeBot|Claude-Web)) {
+      return 403;
+    }
+
     # Load any locations from other roles
     include /etc/nginx/locations-enabled/*;
 

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -103,6 +103,11 @@ http {
     proxy_set_header X-Forwarded-Proto  https;
     proxy_set_header Host               $host;
 
+    # Stop abusive ClaudeBot (via Mythic)
+    if ($http_user_agent ~* (ClaudeBot|Claude-Web)) {
+      return 403;
+    }
+
     location /.well-known/ {
       root            /var/www;
       error_page      403 404 =404 /404.html;


### PR DESCRIPTION
## Summary

It seems ClaudeBot [doesn't obey `robots.txt`](https://servebolt.com/articles/servebolts-decision-to-block-bytespider-and-claudebot/) and makes a large number of requests.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

```console
ansible (block-claudebot)$ curl -Ik https://sr-proxy/ --header 'User-Agent: ClaudeBot'
HTTP/2 403 
server: nginx/1.18.0 (Ubuntu)
date: Wed, 21 Aug 2024 20:29:16 GMT
content-type: text/html
content-length: 162
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN

ansible (block-claudebot)$ curl -Ik https://sr-proxy/ 
HTTP/2 200 
server: nginx/1.18.0 (Ubuntu)
date: Wed, 21 Aug 2024 20:29:20 GMT
content-type: text/html; charset=utf-8
permissions-policy: interest-cohort=()
last-modified: Wed, 21 Aug 2024 00:22:45 GMT
access-control-allow-origin: *
etag: W/"66c53355-5189"
expires: Wed, 21 Aug 2024 00:36:24 GMT
cache-control: max-age=600
x-proxy-cache: MISS
x-github-request-id: BEDF:3FB0E3:221B046:22BC54A:66C5342B
accept-ranges: bytes
age: 0
via: 1.1 varnish
x-served-by: cache-lon4283-LON
x-cache: HIT
x-cache-hits: 0
x-timer: S1724272160.978336,VS0,VE85
vary: Accept-Encoding
x-fastly-request-id: 8aa3d5df87728424c7a24107941cb7627d764c61
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
```
