### PR TITLE
Add role to install clatd

### DIFF
--- a/host_vars/competitorsvcs.studentrobotics.org.yml
+++ b/host_vars/competitorsvcs.studentrobotics.org.yml
@@ -13,5 +13,4 @@ certbot_certs:
       - "{{ canonical_hostname }}"
 
 # Mythic have additionally routed this IP to the VM
-clatd_conf: |
-  clat-v6-addr=2a00:1098:80:bc::2
+clat_v6_addr: 2a00:1098:80:bc::2

--- a/host_vars/competitorsvcs.studentrobotics.org.yml
+++ b/host_vars/competitorsvcs.studentrobotics.org.yml
@@ -11,3 +11,7 @@ add_hsts_header: true
 certbot_certs:
   - domains:
       - "{{ canonical_hostname }}"
+
+# Mythic have additionally routed this IP to the VM
+clatd_conf: |
+  clat-v6-addr=2a00:1098:80:bc::2

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,6 +20,7 @@
   roles:
     - competitor-services-nginx
     - code-submitter
+    - clatd
     - discord-bot
 
 - name: Kit services

--- a/roles/clatd/README.md
+++ b/roles/clatd/README.md
@@ -1,0 +1,5 @@
+# [`clatd`](https://github.com/toreanderson/clatd)
+
+A CLAT / SIIT-DC Edge Relay implementation for Linux.
+
+Used to provide IPv4 outbound connectivity to an IPv6-only VM.

--- a/roles/clatd/README.md
+++ b/roles/clatd/README.md
@@ -3,3 +3,5 @@
 A CLAT / SIIT-DC Edge Relay implementation for Linux.
 
 Used to provide IPv4 outbound connectivity to an IPv6-only VM.
+
+It's likely `clat-v6-addr` will need to be configured to assign the correct IP to the created `clat` interface. This may require an additional IPv6 address be routed to the VM. This is configured with the `clatd_conf` variable.

--- a/roles/clatd/README.md
+++ b/roles/clatd/README.md
@@ -4,4 +4,4 @@ A CLAT / SIIT-DC Edge Relay implementation for Linux.
 
 Used to provide IPv4 outbound connectivity to an IPv6-only VM.
 
-It's likely `clat-v6-addr` will need to be configured to assign the correct IP to the created `clat` interface. This may require an additional IPv6 address be routed to the VM. This is configured with the `clatd_conf` variable.
+It's likely `clat-v6-addr` will need to be configured to assign the correct IP to the created `clat` interface. This may require an additional IPv6 address be routed to the VM.

--- a/roles/clatd/defaults/main.yml
+++ b/roles/clatd/defaults/main.yml
@@ -1,1 +1,0 @@
-clatd_conf: ""

--- a/roles/clatd/defaults/main.yml
+++ b/roles/clatd/defaults/main.yml
@@ -1,0 +1,1 @@
+clatd_conf: ""

--- a/roles/clatd/handlers/main.yml
+++ b/roles/clatd/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart clatd
+  service:
+    name: clatd
+    state: restarted

--- a/roles/clatd/tasks/main.yml
+++ b/roles/clatd/tasks/main.yml
@@ -36,8 +36,8 @@
   when: install_clatd.changed   # noqa: no-handler - Use a handler to ensure execution order
 
 - name: Install configuration
-  copy:
-    content: "{{ clatd_conf }}"
+  template:
+    src: clatd.conf
     dest: /etc/clatd.conf
     mode: "0644"
   notify: Restart clatd

--- a/roles/clatd/tasks/main.yml
+++ b/roles/clatd/tasks/main.yml
@@ -1,0 +1,30 @@
+- name: Download
+  git:
+    repo: https://github.com/toreanderson/clatd
+    dest: "{{ install_dir }}"
+    force: true
+    version: 3ea303b5210bf701df30323933c86f9ffe4d3dd4
+  notify: Restart clatd
+  register: clatd_repo
+
+- name: Install
+  community.general.make:
+    chdir: "{{ install_dir }}"
+    targets:
+      - installdeps  # Install system dependencies
+      - install  # Install clatd
+  when: clatd_repo.changed  # noqa: no-handler - Use a handler to ensure execution order
+  notify: Restart clatd
+
+- name: Install configuration
+  copy:
+    content: "{{ clatd_conf }}"
+    dest: /etc/clatd.conf
+    mode: "0644"
+  notify: Restart clatd
+
+- name: Enable service
+  service:
+    name: clatd
+    state: started
+    enabled: true

--- a/roles/clatd/tasks/main.yml
+++ b/roles/clatd/tasks/main.yml
@@ -4,8 +4,19 @@
     dest: "{{ install_dir }}"
     force: true
     version: 3ea303b5210bf701df30323933c86f9ffe4d3dd4
-  notify: Restart clatd
   register: clatd_repo
+  notify: Restart clatd
+
+- name: Get installed version (if installed)
+  slurp:
+    src: "{{ installed_version_file }}"
+  ignore_errors: true  # Ignore if the file is missing, since it's about to be created
+  register: installed_version_slurp
+
+- name: Resolve installed version
+  set_fact:
+    installed_version: "{{ installed_version_slurp.content | b64decode }}"
+  when: not installed_version_slurp.failed
 
 - name: Install
   community.general.make:
@@ -13,8 +24,16 @@
     targets:
       - installdeps  # Install system dependencies
       - install  # Install clatd
-  when: clatd_repo.changed  # noqa: no-handler - Use a handler to ensure execution order
+  when: installed_version is not defined or clatd_repo.after not in installed_version  # noqa: no-handler - Use a handler to ensure execution order
   notify: Restart clatd
+  register: install_clatd
+
+- name: Update installed version
+  copy:
+    content: "{{ clatd_repo.after }}"
+    dest: "{{ installed_version_file }}"
+    mode: "0644"
+  when: install_clatd.changed   # noqa: no-handler - Use a handler to ensure execution order
 
 - name: Install configuration
   copy:

--- a/roles/clatd/templates/clatd.conf
+++ b/roles/clatd/templates/clatd.conf
@@ -1,0 +1,3 @@
+{% if clat_v6_addr is defined %}
+clat-v6-addr={{ clat_v6_addr }}
+{% endif %}

--- a/roles/clatd/vars/main.yml
+++ b/roles/clatd/vars/main.yml
@@ -1,1 +1,2 @@
 install_dir: /opt/clatd
+installed_version_file: /opt/clatd.version

--- a/roles/clatd/vars/main.yml
+++ b/roles/clatd/vars/main.yml
@@ -1,0 +1,1 @@
+install_dir: /opt/clatd


### PR DESCRIPTION
## Summary

[`clatd`](https://github.com/toreanderson/clatd/) is a _magical_ :sparkles:  tool I don't quite understand which allows our VMs to have outbound IPv4 connectivity, without needing a dedicated address. This avoids the need to have an IPv4 address for the VM. The tool was recommended by Mythic, who also helped with the configuration.

Specifically, this is needed for the Discord bot, since Discord's API is known to be unhappy with IPv6-only connections.

I've intentionally leant on the `Makefile` in the project, rather than duplicating the dependencies, to allow for simpler upgrades in future.

## Code review

### Testing

- [x] applied the configuration locally
- [ ] manually validated the new behaviour

<!-- please do mention any other useful details -->

### Links

The configuration itself has already been tested on the server.
