### PR TITLE
Add redirect to fix misprinted kit list document

### DIFF
--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -258,6 +258,9 @@ http {
 
     rewrite ^/tasks https://github.com/orgs/srobo/projects/24/ redirect;
 
+    # Fix misprinted kit return instructions
+    rewrite ^/kit/return /docs/kit/return redirect;
+
     # SR Boards
     rewrite ^/kch /docs/kit/brain_board redirect;
     rewrite ^/mcv4 /docs/kit/motor_board redirect;


### PR DESCRIPTION
## Summary

There was a misprint on the kit list.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

<!-- please do mention any other useful details -->

### Links

https://docs.google.com/document/d/1N7mYdnkpsnXOb0nHRRT2rYhcLqEnq8EndQXVNaE884E/edit?usp=sharing
