### PR TITLE
Create the code-submitter database if missing

### DIFF
--- a/roles/code-submitter/tasks/main.yml
+++ b/roles/code-submitter/tasks/main.yml
@@ -91,7 +91,7 @@
   environment:
     PYTHONPATH: "{{ install_dir }}"
   become_user: www-data
-  when: |  # noqa: no-handler - Use a handler to ensure execution order
+  when: |
     code_submitter_repo.changed or
     database_file.stat.isreg is not defined or
     not database_file.stat.isreg

--- a/roles/code-submitter/tasks/main.yml
+++ b/roles/code-submitter/tasks/main.yml
@@ -77,9 +77,9 @@
     Reload nginx
 
 - name: Check if database exists
-  shell: test -f "{{ install_dir }}/sqlite.db" || echo "Missing"
-  register: detect_database
-  changed_when: detect_database.stdout.startswith("Missing")
+  stat:
+    path: "{{ install_dir }}/sqlite.db"
+  register: database_file
 
 - name: Install database  # noqa: no-changed-when - We want to always run this (it handles its own idempotency)
   shell:  # noqa: command-instead-of-shell - We need this to use `environment`
@@ -91,7 +91,10 @@
   environment:
     PYTHONPATH: "{{ install_dir }}"
   become_user: www-data
-  when: code_submitter_repo.changed or detect_database.changed  # noqa: no-handler - Use a handler to ensure execution order
+  when: |  # noqa: no-handler - Use a handler to ensure execution order
+    code_submitter_repo.changed or
+    database_file.stat.isreg is not defined or
+    not database_file.stat.isreg
 
 - name: Enable service
   service:

--- a/roles/code-submitter/tasks/main.yml
+++ b/roles/code-submitter/tasks/main.yml
@@ -76,6 +76,11 @@
   notify:
     Reload nginx
 
+- name: Check if database exists
+  shell: test -f "{{ install_dir }}/sqlite.db" || echo "Missing"
+  register: detect_database
+  changed_when: detect_database.stdout.startswith("Missing")
+
 - name: Install database  # noqa: no-changed-when - We want to always run this (it handles its own idempotency)
   shell:  # noqa: command-instead-of-shell - We need this to use `environment`
     argv:
@@ -86,7 +91,7 @@
   environment:
     PYTHONPATH: "{{ install_dir }}"
   become_user: www-data
-  when: code_submitter_repo.changed  # noqa: no-handler - Use a handler to ensure execution order
+  when: code_submitter_repo.changed or detect_database.changed  # noqa: no-handler - Use a handler to ensure execution order
 
 - name: Enable service
   service:

--- a/roles/code-submitter/tasks/main.yml
+++ b/roles/code-submitter/tasks/main.yml
@@ -82,9 +82,9 @@
       - "{{ venv_dir }}/bin/alembic"
       - upgrade
       - head
-    chdir: /srv/code-submitter
+    chdir: "{{ install_dir }}"
   environment:
-    PYTHONPATH: /srv/code-submitter
+    PYTHONPATH: "{{ install_dir }}"
   become_user: www-data
   when: code_submitter_repo.changed  # noqa: no-handler - Use a handler to ensure execution order
 


### PR DESCRIPTION
## Summary

This ensures that the database can be re-created if it's been removed (as we do between SR years), even if the code hasn't changed.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour

Tested by running from scratch (i.e: no code-submitter directory present), from a fully built state and from a state where only the database was missing.  Verified in each case that the database was either created or not changed as needed.

### Links

Fixes https://github.com/srobo/ansible/issues/58.

https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html#basic-conditionals-with-when