### PR TITLE
Disable competition homepage after SR2025 virtual competition

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -21,7 +21,7 @@ enable_srcomp_proxy: true
 srcomp_proxy_hostname: srcomp.studentrobotics.org
 # Override serving of the root url to be the competition mode homepage instead
 # of the normal one.
-enable_competition_homepage: true
+enable_competition_homepage: false
 
 # We typically only host the competitor services for the duration of the
 # competition year.


### PR DESCRIPTION
## Summary

Blocked on (and based off) #82 

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour
- [x] N/A

<!-- please do mention any other useful details -->

### Links

<!-- any useful or relevant links, including Slack discussions & documentation -->
