### PR TITLE
Rebrand kit services to competition services

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ to test any **HTTP** services they're running. Add the following line to
 
 ```
 192.168.56.56  sr-proxy sr-proxy.local
-192.168.56.57  sr-compsvc sr-compsvc.local
-192.168.56.58  sr-kitsvc sr-kitsvc.local
+192.168.56.57  sr-competitorsvcs sr-competitorsvcs.local
+192.168.56.58  sr-competitionsvcs sr-competitionsvcs.local
 ```
 
 You'll then be able to access the machines as if they were hosted. For example

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,8 @@ Vagrant.configure(2) do |config|
 
     ansible.groups = {
       "webproxies" => ["sr-proxy"],
-      "competitorsvcs" => ["sr-compsvc"],
-      "kitsvcs" => ["sr-kitsvc"],
+      "competitorsvcs" => ["sr-competitorsvc"],
+      "competitionsvcs" => ["sr-competitionsvcs"],
     }
   end
 
@@ -27,23 +27,23 @@ Vagrant.configure(2) do |config|
     web.vm.hostname = "sr-proxy.local"
   end
 
-  config.vm.define "sr-compsvc" do |compsrv|
-    compsrv.vm.box = "ubuntu/jammy64"
+  config.vm.define "sr-competitorsvcs" do |competitorsrv|
+    competitorsrv.vm.box = "ubuntu/jammy64"
 
     # This name is what's looked up in the Ansible host_vars.
-    compsrv.vm.define "sr-compsvc"
+    competitorsrv.vm.define "sr-competitorsvcs"
 
-    compsrv.vm.network "private_network", ip: "192.168.56.57"
-    compsrv.vm.hostname = "sr-compsvc.local"
+    competitorsrv.vm.network "private_network", ip: "192.168.56.57"
+    competitorsrv.vm.hostname = "sr-competitorsvcs.local"
   end
 
-  config.vm.define "sr-kitsvc" do |kitsrv|
-    kitsrv.vm.box = "ubuntu/jammy64"
+  config.vm.define "sr-competitionsvcs" do |competitionsrv|
+    competitionsrv.vm.box = "ubuntu/jammy64"
 
     # This name is what's looked up in the Ansible host_vars.
-    kitsrv.vm.define "sr-kitsvc"
+    competitionsrv.vm.define "sr-competitionsvcs"
 
-    kitsrv.vm.network "private_network", ip: "192.168.56.58"
-    kitsrv.vm.hostname = "sr-kitsvc.local"
+    competitionsrv.vm.network "private_network", ip: "192.168.56.58"
+    competitionsrv.vm.hostname = "sr-competitionsvcs.local"
   end
 end

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -28,10 +28,10 @@ enable_competition_homepage: false
 enable_competitor_services_proxy: true
 competitor_services_proxy_hostname: competitorsvcs.studentrobotics.org
 
-# We typically only host the kit services for the duration of the
+# We typically only host the competition services for the duration of the
 # competition year.
-enable_kit_services_proxy: true
-kit_services_proxy_hostname: kitsvcs.studentrobotics.org
+enable_competition_services_proxy: true
+competition_services_proxy_hostname: competitionsvcs.studentrobotics.org
 
 firewall_allowed_tcp_ports:
  - "22"

--- a/host_vars/competitionsvcs.studentrobotics.org.yml
+++ b/host_vars/competitionsvcs.studentrobotics.org.yml
@@ -1,5 +1,5 @@
 ---
-canonical_hostname: kitsvcs.studentrobotics.org
+canonical_hostname: competitionsvcs.studentrobotics.org
 secondary_hostnames:
   # Include our primary canonical hostname so that requests via the proxy there
   # aren't redirected. This is needed (rather than overriding the Host header

--- a/host_vars/sr-competitionsvcs.yml
+++ b/host_vars/sr-competitionsvcs.yml
@@ -1,9 +1,9 @@
 ---
 # This is a dev VM created by Vagrant.
 
-canonical_hostname: sr-compsvc
+canonical_hostname: sr-competitionsvcs
 secondary_hostnames:
-  # See explanation in host_vars/competitorsvcs.studentrobotics.org.yml for why
+  # See explanation in host_vars/competitionsvcs.studentrobotics.org.yml for why
   # we include the proxy hostname here.
   - sr-proxy
 

--- a/host_vars/sr-competitorsvcs.yml
+++ b/host_vars/sr-competitorsvcs.yml
@@ -1,9 +1,9 @@
 ---
 # This is a dev VM created by Vagrant.
 
-canonical_hostname: sr-kitsvc
+canonical_hostname: sr-competitorsvc
 secondary_hostnames:
-  # See explanation in host_vars/kitsvcs.studentrobotics.org.yml for why
+  # See explanation in host_vars/competitorsvcs.studentrobotics.org.yml for why
   # we include the proxy hostname here.
   - sr-proxy
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -24,8 +24,8 @@
     - clatd
     - discord-bot
 
-- name: Kit services
-  hosts: kitsvcs
+- name: Competition services
+  hosts: competitionsvcs
   roles:
     # TODO: Give this role a less machine-specific name
     - competitor-services-nginx

--- a/roles/competitor-services-nginx/README.md
+++ b/roles/competitor-services-nginx/README.md
@@ -7,13 +7,13 @@ services. Currently this is just the [Code Submitter](../code-submitter/README.m
 
 1. Follow the [general instructions](../../README.md) for ansible development.
 
-2. Visit <https://sr-compsvc> in a browser (approve the self-signed local TLS
+2. Visit <https://sr-competitorsvc> in a browser (approve the self-signed local TLS
    certificate if needed), and confirm that you see a copy of the SR website
    (also check that you didn't get redirect to the real one!)
 
 3. Make your changes to [`templates/nginx.conf`](templates/nginx.conf)
 
-4. Reprovision the VM, thus deploying the changes: `vagrant provision sr-compsvc`
+4. Reprovision the VM, thus deploying the changes: `vagrant provision sr-competitorsvc`
 
 5. Refresh your browser and bask in the glory of your changes
 

--- a/roles/srobo-nginx/templates/nginx.conf
+++ b/roles/srobo-nginx/templates/nginx.conf
@@ -128,13 +128,13 @@ http {
       }
     {% endif %}
 
-    {% if enable_kit_services_proxy %}
+    {% if enable_competition_services_proxy %}
       location /helpdesk/ {
         # When the proxied service is not available NGINX will refuse to start.
         # Use a variable to trick it into connecting lazily and thus always
         # starting up, even if in a degraded mode.
-        set $kitsvcs '{{ kit_services_proxy_hostname }}';
-        proxy_pass https://$kitsvcs$request_uri;
+        set $competitionsvcs '{{ competition_services_proxy_hostname }}';
+        proxy_pass https://$competitionsvcs$request_uri;
         # Note: don't set a Host header as we want the helpdesk system to use our
         # public hostname, not the hostname of the underlying machine.
       }


### PR DESCRIPTION
## Summary

"kit" doesn't really have any services anymore. The previous services were only the helpdesk system, which is more of a competition thing.

This PR rebrands it to the "competition services" machine, so it can host more competition-related services.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour
- [ ] The act of testing or proving
- [x] Delegate

### Links

<!-- any useful or relevant links, including Slack discussions & documentation -->
