### PR TITLE
Update sr-proxy to Ubuntu Noble 24.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure(2) do |config|
 
   # This name is what's looked up in the Ansible host_vars.
   config.vm.define "sr-proxy" do |web|
-    web.vm.box = "ubuntu/focal64"
+    web.vm.box = "bento/ubuntu-24.04"
 
     web.vm.network "private_network", ip: "192.168.56.56"
     web.vm.hostname = "sr-proxy.local"


### PR DESCRIPTION
## Summary

Ubuntu Focal (20.04) is nearing end of life and Mythic have offered to upgrade it to Noble. This change updates our `Vagrantfile` to match that, which I then used to check that the ansible config would apply cleanly (which it does). Obviously this isn't quite the same as the in-place upgrade they'll do, but is still useful.

## Code review

### Testing

- [x] applied the configuration locally
- [x] manually validated the new behaviour (checked some proxy urls and some redirects)
