### PR TITLE
Ensure services are restarted on failure

### DIFF
--- a/roles/code-submitter/templates/code-submitter.service
+++ b/roles/code-submitter/templates/code-submitter.service
@@ -12,5 +12,8 @@ RuntimeDirectory=code-submitter
 # `--forwarded-allow-ips` is safe here as we're listening on a UNIX socket
 ExecStart={{ venv_dir }}/bin/uvicorn code_submitter.server:app --uds /var/run/code-submitter/code-submitter.socket --forwarded-allow-ips='*' --root-path /code-submitter
 
+Restart=always
+RestartSec=5s
+
 [Install]
 WantedBy=multi-user.target

--- a/roles/code-submitter/templates/code-submitter.service
+++ b/roles/code-submitter/templates/code-submitter.service
@@ -13,7 +13,6 @@ RuntimeDirectory=code-submitter
 ExecStart={{ venv_dir }}/bin/uvicorn code_submitter.server:app --uds /var/run/code-submitter/code-submitter.socket --forwarded-allow-ips='*' --root-path /code-submitter
 
 Restart=always
-RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/discord-bot/templates/discord-bot.service
+++ b/roles/discord-bot/templates/discord-bot.service
@@ -10,7 +10,6 @@ RuntimeDirectory=discord-bot
 ExecStart={{ venv_dir }}/bin/python -m sr.discord_bot
 
 Restart=always
-RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/discord-bot/templates/discord-bot.service
+++ b/roles/discord-bot/templates/discord-bot.service
@@ -4,9 +4,12 @@ After=network.target
 
 [Service]
 User=discord
+
 Type=simple
+
 WorkingDirectory={{ install_dir }}
 RuntimeDirectory=discord-bot
+
 ExecStart={{ venv_dir }}/bin/python -m sr.discord_bot
 
 Restart=always

--- a/roles/discord-bot/templates/discord-bot.service
+++ b/roles/discord-bot/templates/discord-bot.service
@@ -4,13 +4,13 @@ After=network.target
 
 [Service]
 User=discord
-
 Type=simple
-
 WorkingDirectory={{ install_dir }}
 RuntimeDirectory=discord-bot
-
 ExecStart={{ venv_dir }}/bin/python -m sr.discord_bot
+
+Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/helpdesk-system/templates/helpdesk-system.service
+++ b/roles/helpdesk-system/templates/helpdesk-system.service
@@ -4,12 +4,13 @@ After=network.target
 
 [Service]
 User=www-data
-
 Type=simple
-
 WorkingDirectory={{ install_dir }}/helpdesk
 RuntimeDirectory=helpdesk-system
 ExecStart={{ venv_dir }}/bin/gunicorn helpdesk.wsgi:application --bind unix:/var/run/helpdesk-system/helpdesk-system.socket --forwarded-allow-ips='*' --access-logfile - --workers="{{ ansible_processor_nproc * 2 + 1 }}" --max-requests=500 --max-requests-jitter=20 --timeout=30
+
+Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/helpdesk-system/templates/helpdesk-system.service
+++ b/roles/helpdesk-system/templates/helpdesk-system.service
@@ -10,7 +10,6 @@ RuntimeDirectory=helpdesk-system
 ExecStart={{ venv_dir }}/bin/gunicorn helpdesk.wsgi:application --bind unix:/var/run/helpdesk-system/helpdesk-system.socket --forwarded-allow-ips='*' --access-logfile - --workers="{{ ansible_processor_nproc * 2 + 1 }}" --max-requests=500 --max-requests-jitter=20 --timeout=30
 
 Restart=always
-RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/helpdesk-system/templates/helpdesk-system.service
+++ b/roles/helpdesk-system/templates/helpdesk-system.service
@@ -4,7 +4,9 @@ After=network.target
 
 [Service]
 User=www-data
+
 Type=simple
+
 WorkingDirectory={{ install_dir }}/helpdesk
 RuntimeDirectory=helpdesk-system
 ExecStart={{ venv_dir }}/bin/gunicorn helpdesk.wsgi:application --bind unix:/var/run/helpdesk-system/helpdesk-system.socket --forwarded-allow-ips='*' --access-logfile - --workers="{{ ansible_processor_nproc * 2 + 1 }}" --max-requests=500 --max-requests-jitter=20 --timeout=30

--- a/roles/volunteersys/templates/volunteersys.service
+++ b/roles/volunteersys/templates/volunteersys.service
@@ -10,7 +10,6 @@ WorkingDirectory={{ install_dir }}
 ExecStart=/usr/local/bin/bun run src/main.ts
 
 Restart=always
-RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/volunteersys/templates/volunteersys.service
+++ b/roles/volunteersys/templates/volunteersys.service
@@ -9,5 +9,8 @@ EnvironmentFile={{ volunteersys_secrets_dir }}/secrets.env
 WorkingDirectory={{ install_dir }}
 ExecStart=/usr/local/bin/bun run src/main.ts
 
+Restart=always
+RestartSec=5s
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

When any of the services terminate uncleanly, they are not (currently) restarted. This causes availability issues.

This PR uses systemd's native `Restart` behaviour to wait 5 seconds before restarting. 5 seconds might seem like a while (the default is 100ms), but it hopefully ensures any transient issues have passed.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour

### Links

See also https://github.com/srobo/discord-bot/issues/46

Docs: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html
