### PR TITLE
Build vagrant machines in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,27 @@ jobs:
 
       - name: Run linters
         run: ./scripts/lint.sh
+
+  vagrant:
+    # macOS runners support nested virtualization
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        vm: [sr-proxy, sr-competitorsvcs, sr-competitionsvcs]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v4
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-
+
+      - name: Show Vagrant version
+        run: vagrant --version
+
+      - name: Run vagrant up
+        run: vagrant up ${{ matrix.vm }}


### PR DESCRIPTION
## Summary

Building the vagrant boxes in CI gives us better assurances that the boxes will work once deployed.

Or, in other words: CI good.

## Code review

### Testing

- [ ] applied the configuration locally
- [ ] manually validated the new behaviour
- [ ] CI go _brrrrrrrr_

<!-- please do mention any other useful details -->

### Links

https://github.com/jonashackt/vagrant-github-actions
